### PR TITLE
feat(cli): add Bun as a package manager option

### DIFF
--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -1,0 +1,82 @@
+# HANDOFF — create-next-stack (akd-io) + create-stack-next
+
+**Última actualización:** 2026-07-14
+**Sesión origen:** webchat Mini, sesión CSN+CNS
+
+---
+
+## Contexto general
+
+Gonzo decidió colaborar con `create-next-stack` (akd-io) en lugar de competir. `create-stack-next` (nuestro) queda como "fork opinado" / laboratorio — lo que funciona se manda upstream. Todo lo que vaya al repo de akd-io va en inglés. Esta sesión es exclusivamente CSN + CNS.
+
+## Estado actual
+
+- **PR #280 abierto:** Bun support (#262) — https://github.com/akd-io/create-next-stack/pull/280
+- Esperando review de akd-io
+- CI: GitGuardian ✅, Vercel CI awaiting maintainer approval (normal para PRs externos)
+- Repo forkeado: github.com/gonzoblasco/create-next-stack
+- Clonado en `projects/create-next-stack`, rama `feature/262-add-bun-support`
+
+## Plan de PRs — orden priorizado y por qué
+
+### 1. ✅ Bun support (#262) — HECHO (PR #280)
+
+- **Por qué primero:** Ya lo teníamos implementado en CSN. Sabíamos hacerlo. PR rápido y de alto valor (Bun es el PM más nuevo y solicitado).
+- **Commits:**
+  - `feat(cli): add Bun as a package manager option (#262)`
+  - `test(e2e): add E2E test for Bun package manager (#262)`
+- **Archivos:** 9 files, +90/-2 líneas
+
+### 2. 🔜 Vitest (#224) — próximo PR
+
+- **Por qué segundo:** Ironía — ellos ya migraron a Vitest internamente (reemplazaron Jest) pero NO lo ofrecen como opción del scaffold. Es un gap obvio. Además nosotros lo usamos en CSN, lo conocemos.
+- **Cuándo:** en ~2 semanas si no hay respuesta al PR de Bun. Si responden antes, seguimos el ritmo que marquen.
+- **Issue:** https://github.com/akd-io/create-next-stack/issues/224
+- **Comentario de akd-io:** remite a https://nextjs.org/docs/pages/building-your-application/optimizing/testing
+
+### 3. Supabase (#249)
+
+- **Por qué tercero:** Lo dominamos por SoporteML (Supabase + pgvector + Edge Functions). Es un plugin más grande (setup de cliente, env vars, tipos, opcional DB) pero sabemos exactamente cómo hacerlo.
+- **Issue:** https://github.com/akd-io/create-next-stack/issues/249
+
+### 4. Auth.js + ShadCN (#268)
+
+- **Por qué:** Muy pedido (issue sin body, solo título, pero ShadCN es lo más usado hoy). Auth.js (antes NextAuth) es el estándar de auth en Next.js. Juntos son un combo que mucha gente quiere.
+- **Issue:** https://github.com/akd-io/create-next-stack/issues/268
+
+### 5. Architecture review (#272)
+
+- **Por qué es el "golazo":** Si entramos acá, nos posicionamos como alguien que entiende la arquitectura completa del proyecto, no solo un contributor que arregla typos. Es el salto de "colaborador" a "alguien que piensa el proyecto".
+- **Issue:** https://github.com/akd-io/create-next-stack/issues/272
+
+### 6. OpenSpec como feature propuesta
+
+- **Por qué último:** Es nuestra tarjeta de presentación — Spec-Driven Development embebido. Pero proponerlo sin credibilidad previa = ruido. Después de 2-3 PRs merged, proponemos OpenSpec con peso real.
+- **No tiene issue** — se propondría como discussion o feature request nueva.
+
+## Issues chicos para ganar credibilidad rápida (si hace falta)
+
+Si akd-io no responde al PR grande y queremos mantener momentum, estos son fixes chicos y claros:
+
+- **#277 — Remove `React.FC` usage (CLI):** El website ya está hecho (#275), falta el CLI. Limpieza de código, bien definido.
+- **#231 — CLI crashes if git username/email isn't specified:** Bug claro con reproducción. akd-io dejó pistas de cómo arreglarlo en los comments.
+- **#266 — prettier-plugin-organize-imports:** Ellos ya lo usan internamente (Phase 4 del #271) pero no lo ofrecen como opción del scaffold.
+
+## Deuda congelada
+
+- **Website de CNS** (create-next-stack.com): actualizarlo para soportar Bun y futuras opciones. Está en el FREEZER — deuda moral después del CLI. No mezclar en el PR del CLI.
+
+## Estructura del repo de akd-io (para referencia)
+
+- Monorepo con pnpm + Turbo
+- `packages/create-next-stack/` — el CLI (oclif, TypeScript, ESM)
+  - `src/main/plugins/` — un .ts por tecnología/plugin
+  - `src/main/setup/setup.ts` — registro de plugins
+  - `src/main/steps.ts` — orden de steps
+  - `src/main/create-next-stack-types.ts` — tipos y opciones de flags
+  - `src/main/helpers/package-manager-utils.ts` — mapas por PM
+  - `src/main/plugins/create-next-stack/sort-orders/technologies.ts` — sort order de technologies
+  - `src/tests/e2e/tests/` — un test por PM/styling/config
+- `apps/website/` — Next.js 16, Mantine, form interactivo
+- `CONTRIBUTING.md` — guía completa de cómo agregar plugins
+- Pre-commit hook actualiza README automáticamente

--- a/packages/create-next-stack/README.md
+++ b/packages/create-next-stack/README.md
@@ -59,6 +59,7 @@ The table below provides an overview of the technologies currently supported by 
 | pnpm                | [Website](https://pnpm.io/) - [Docs](https://pnpm.io/motivation) - [GitHub](https://github.com/pnpm/pnpm)                                                                                                                    |
 | Yarn                | [Website](https://yarnpkg.com/) - [CLI Docs](https://yarnpkg.com/cli) - [GitHub](https://github.com/yarnpkg/berry)                                                                                                           |
 | npm                 | [Website](https://www.npmjs.com/) - [Docs](https://docs.npmjs.com/) - [GitHub](https://github.com/npm/cli)                                                                                                                   |
+| Bun                 | [Website](https://bun.sh/) - [Docs](https://bun.sh/docs) - [GitHub](https://github.com/oven-sh/bun)                                                                                                                          |
 | GitHub Actions      | [Website](https://github.com/features/actions) - [Docs](https://docs.github.com/en/actions) - [Workflow syntax](https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions)                             |
 | Plausible Analytics | [Website](https://plausible.io/) - [Docs](https://plausible.io/docs) - [GitHub](https://github.com/plausible/analytics)                                                                                                      |
 | next-plausible      | [Website](https://next-plausible.vercel.app/) - [GitHub](https://github.com/4lejandrito/next-plausible)                                                                                                                      |
@@ -101,7 +102,7 @@ FLAGS
       --netlify                     Adds Netlify. (Hosting)
       --package-manager=<option>    (required) Sets the preferred package
                                     manager. (Required)
-                                    <options: pnpm|yarn|npm>
+                                    <options: pnpm|yarn|npm|bun>
       --plausible                   Adds Plausible. (Analytics)
       --prettier                    Adds Prettier. (Code formatting)
       --prisma                      Adds Prisma. (ORM)

--- a/packages/create-next-stack/src/main/create-next-stack-types.ts
+++ b/packages/create-next-stack/src/main/create-next-stack-types.ts
@@ -32,7 +32,7 @@ export const writableRouterOptions = routerOptions as Writable<
 >
 
 // Package manager flag:
-export const packageManagerOptions = ["pnpm", "yarn", "npm"] as const
+export const packageManagerOptions = ["pnpm", "yarn", "npm", "bun"] as const
 export type PackageManager = (typeof packageManagerOptions)[number]
 export const writablePackageManagerOptions = packageManagerOptions as Writable<
   typeof packageManagerOptions

--- a/packages/create-next-stack/src/main/helpers/package-manager-utils.ts
+++ b/packages/create-next-stack/src/main/helpers/package-manager-utils.ts
@@ -4,34 +4,40 @@ export const installCommandMap: Record<PackageManager, string> = {
   pnpm: "pnpm install",
   yarn: "yarn",
   npm: "npm install",
+  bun: "bun install",
 }
 
 export const cleanInstallCommandMap: Record<PackageManager, string> = {
   pnpm: "pnpm install --frozen-lockfile",
   yarn: "yarn install --frozen-lockfile",
   npm: "npm ci",
+  bun: "bun install --frozen-lockfile",
 }
 
 export const installSubCommandMap: Record<PackageManager, string> = {
   pnpm: "add",
   yarn: "add",
   npm: "install",
+  bun: "add",
 }
 
 export const uninstallSubCommandMap: Record<PackageManager, string> = {
   pnpm: "remove",
   yarn: "remove",
   npm: "uninstall",
+  bun: "remove",
 }
 
 export const runCommandMap: Record<PackageManager, string> = {
   pnpm: "pnpm",
   yarn: "yarn",
   npm: "npm run",
+  bun: "bun run",
 }
 
 export const saveDevModifierMap: Record<PackageManager, string> = {
   pnpm: "--save-dev",
   yarn: "--dev",
   npm: "--save-dev",
+  bun: "--dev",
 }

--- a/packages/create-next-stack/src/main/plugins/bun.ts
+++ b/packages/create-next-stack/src/main/plugins/bun.ts
@@ -1,0 +1,31 @@
+import { runCommand } from "../helpers/run-command.ts"
+import type { Plugin } from "../plugin.ts"
+
+export const bunPlugin: Plugin = {
+  id: "bun",
+  name: "Bun",
+  description: "Adds support for Bun",
+  active: ({ flags }) => Boolean(flags["package-manager"] === "bun"),
+  technologies: [
+    {
+      id: "bun",
+      name: "Bun",
+      description:
+        "Bun is an all-in-one toolkit for JavaScript and TypeScript apps. It ships as a single binary that implements a fast package manager, a bundler, a test runner, and a runtime built on JavaScriptCore. Bun is designed as a drop-in replacement for Node.js and is compatible with most npm packages.",
+      links: [
+        { title: "Website", url: "https://bun.sh/" },
+        { title: "Docs", url: "https://bun.sh/docs" },
+        { title: "GitHub", url: "https://github.com/oven-sh/bun" },
+      ],
+    },
+  ],
+  steps: [
+    {
+      id: "updateBun",
+      description: "updating Bun",
+      run: async () => {
+        await runCommand("bun", ["upgrade"])
+      },
+    },
+  ],
+}

--- a/packages/create-next-stack/src/main/plugins/create-next-stack/sort-orders/technologies.ts
+++ b/packages/create-next-stack/src/main/plugins/create-next-stack/sort-orders/technologies.ts
@@ -28,6 +28,7 @@ export const technologiesSortOrder: string[] = [
   "pnpm",
   "yarn",
   "npm",
+  "bun",
   "githubActions",
   "plausible",
   "nextPlausible",

--- a/packages/create-next-stack/src/main/plugins/next.ts
+++ b/packages/create-next-stack/src/main/plugins/next.ts
@@ -96,6 +96,9 @@ export const nextPlugin: Plugin = {
           case "npm":
             createNextAppArgs.push("--use-npm")
             break
+          case "bun":
+            createNextAppArgs.push("--use-bun")
+            break
         }
 
         await runCommand("npx", [

--- a/packages/create-next-stack/src/main/setup/setup.ts
+++ b/packages/create-next-stack/src/main/setup/setup.ts
@@ -7,6 +7,7 @@ import { inDebugMode } from "../helpers/in-debug-mode.ts"
 import { time } from "../helpers/time.ts"
 import { logDebug, logInfo } from "../logging.ts"
 import { evalOptionalProperty, evalProperty, type Plugin } from "../plugin.ts"
+import { bunPlugin } from "../plugins/bun.ts"
 import { chakraUIPlugin } from "../plugins/chakra-ui.ts"
 import { createNextStackPlugin } from "../plugins/create-next-stack/create-next-stack.ts"
 import { cssModulesPlugin } from "../plugins/css-modules.ts"
@@ -60,6 +61,7 @@ export const plugins: Plugin[] = [
   pnpmPlugin,
   yarnPlugin,
   npmPlugin,
+  bunPlugin,
   githubActionsPlugin,
   reactIconsPlugin,
   reactQueryPlugin,

--- a/packages/create-next-stack/src/main/steps.ts
+++ b/packages/create-next-stack/src/main/steps.ts
@@ -8,6 +8,7 @@ export const stepsOrder: string[] = [
   // Update package manager
   "updatePnpm",
   "updateYarn",
+  "updateBun",
   // Create Next App
   "createNextApp",
   "removeOfficialCNAContent",

--- a/packages/create-next-stack/src/tests/e2e/tests/bun.test.ts
+++ b/packages/create-next-stack/src/tests/e2e/tests/bun.test.ts
@@ -1,0 +1,43 @@
+import { exists } from "../../../main/helpers/exists.ts"
+import { testArgsWithFinalChecks } from "../helpers/test-args.ts"
+import { twentyMinutes } from "../helpers/timeout.ts"
+
+test(
+  "testBun",
+  async () => {
+    const { runDirectory } = await testArgsWithFinalChecks([
+      "--debug",
+      "--package-manager=bun",
+      "--styling=emotion",
+      "--mantine",
+      "--chakra",
+      "--material-ui",
+      "--react-hook-form",
+      "--formik",
+      "--framer-motion",
+      "--prettier",
+      "--formatting-pre-commit-hook",
+      "--react-icons",
+      "--react-query",
+      "--plausible",
+      "--github-actions",
+      "--prisma",
+      "--vercel",
+      "--netlify",
+      ".",
+    ])
+
+    const yarnLockExists = await exists(`${runDirectory}/yarn.lock`)
+    expect(yarnLockExists).toBe(false)
+
+    const packageLockExists = await exists(`${runDirectory}/package-lock.json`)
+    expect(packageLockExists).toBe(false)
+
+    const pnpmLockExists = await exists(`${runDirectory}/pnpm-lock.yaml`)
+    expect(pnpmLockExists).toBe(false)
+
+    const bunLockExists = await exists(`${runDirectory}/bun.lock`)
+    expect(bunLockExists).toBe(true)
+  },
+  twentyMinutes,
+)


### PR DESCRIPTION
## Add support for Bun (#262)

Closes #262

### Summary

Adds Bun as a fourth package manager option alongside pnpm, yarn, and npm.

### Changes

- **New plugin** `bun.ts` with an `updateBun` step that runs `bun upgrade`
- **Type system:** `"bun"` added to `PackageManager` type and oclif flag options
- **Package manager maps:** Bun entries added to all 5 maps in `package-manager-utils.ts` (install, cleanInstall, installSub, uninstallSub, runCommand, saveDev)
- **create-next-app:** `--use-bun` flag passed to CNA when Bun is selected
- **Plugin registration:** `bunPlugin` imported and registered in `setup.ts`
- **Steps order:** `updateBun` added to `stepsOrder` in `steps.ts`
- **Technologies sort order:** `bun` added to `technologiesSortOrder`
- **E2E test:** `bun.test.ts` verifies generated project has `bun.lock` and no other lockfiles
- **README:** auto-updated by pre-commit hook

### Verification

- ✅ `pnpm run build` — clean (CLI + website)
- ✅ `pnpm run lint` — no errors
- ✅ `pnpm run unit` — 9/9 tests pass
- ✅ `./bin/run --help` shows `pnpm|yarn|npm|bun`

### Notes

- Website (create-next-stack.com) is NOT updated in this PR — it can be done in a follow-up PR if desired.
- Bun's `--use-bun` flag is supported by create-next-app since v13.5+.
- `bun upgrade` is used instead of `npm i -g bun` to stay consistent with Bun's own update mechanism.