### PR TITLE
feat(cli): add Vitest as a testing framework option

### DIFF
--- a/packages/create-next-stack/README.md
+++ b/packages/create-next-stack/README.md
@@ -65,6 +65,7 @@ The table below provides an overview of the technologies currently supported by 
 | Vercel              | [Website](https://vercel.com/) - [Docs](https://vercel.com/docs) - [CLI Docs](https://vercel.com/docs/cli)                                                                                                                   |
 | Netlify             | [Website](https://www.netlify.com/) - [Docs](https://docs.netlify.com/) - [CLI Docs](https://cli.netlify.com/)                                                                                                               |
 | Prisma              | [Website](https://www.prisma.io/) - [Docs](https://www.prisma.io/docs) - [GitHub](https://github.com/prisma/prisma)                                                                                                          |
+| Vitest              | [Website](https://vitest.dev/) - [Docs](https://vitest.dev/guide/) - [GitHub](https://github.com/vitest-dev/vitest)                                                                                                          |
 
 <!-- CNS-END-OF-TECHNOLOGIES-TABLE -->
 
@@ -118,6 +119,7 @@ FLAGS
                                     emotion|styled-components|tailwind-css|css-m
                                     odules|css-modules-with-sass
       --vercel                      Adds Vercel. (Hosting)
+      --vitest                      Adds Vitest. (Testing framework)
 ```
 
 <!-- CNS-END-OF-HELP-OUTPUT -->

--- a/packages/create-next-stack/src/main/commands/create-next-stack.ts
+++ b/packages/create-next-stack/src/main/commands/create-next-stack.ts
@@ -125,6 +125,11 @@ export default class CreateNextStack extends Command {
     prisma: Flags.boolean({
       description: "Adds Prisma. (ORM)",
     }),
+
+    // Testing
+    vitest: Flags.boolean({
+      description: "Adds Vitest. (Testing framework)",
+    }),
   }
 
   async run(): Promise<void> {

--- a/packages/create-next-stack/src/main/plugins/create-next-stack/sort-orders/scripts.ts
+++ b/packages/create-next-stack/src/main/plugins/create-next-stack/sort-orders/scripts.ts
@@ -6,6 +6,8 @@ import { filterPlugins } from "../../../setup/setup.ts"
 export const scriptsSortOrder: string[] = [
   "prepare",
   "test",
+  "test:watch",
+  "test:ci",
   "dev",
   "build",
   "start",

--- a/packages/create-next-stack/src/main/plugins/create-next-stack/sort-orders/technologies.ts
+++ b/packages/create-next-stack/src/main/plugins/create-next-stack/sort-orders/technologies.ts
@@ -34,6 +34,7 @@ export const technologiesSortOrder: string[] = [
   "vercel",
   "netlify",
   "prisma",
+  "vitest",
 ]
 
 export const getTechnologies = async (

--- a/packages/create-next-stack/src/main/plugins/vitest.ts
+++ b/packages/create-next-stack/src/main/plugins/vitest.ts
@@ -1,0 +1,50 @@
+import type { Plugin } from "../plugin.ts"
+
+export const vitestPackage = {
+  name: "vitest",
+  version: "^4.0.0",
+} as const
+
+export const vitestPlugin: Plugin = {
+  id: "vitest",
+  name: "Vitest",
+  description: "Adds support for Vitest",
+  active: ({ flags }) => Boolean(flags["vitest"]),
+  devDependencies: [vitestPackage],
+  technologies: [
+    {
+      id: "vitest",
+      name: "Vitest",
+      description:
+        "Vitest is a blazing fast unit-test framework powered by Vite. It provides a Jest-compatible API, native ESM and TypeScript support, and watch mode out of the box. Vitest integrates seamlessly with Vite-powered projects, sharing the same configuration and transform pipeline.",
+      links: [
+        { title: "Website", url: "https://vitest.dev/" },
+        { title: "Docs", url: "https://vitest.dev/guide/" },
+        { title: "GitHub", url: "https://github.com/vitest-dev/vitest" },
+      ],
+    },
+  ],
+  scripts: [
+    {
+      name: "test",
+      description: "Runs unit tests with Vitest.",
+      command: "vitest run",
+    },
+    {
+      name: "test:watch",
+      description: "Runs unit tests in watch mode.",
+      command: "vitest",
+    },
+    {
+      name: "test:ci",
+      description: "Runs unit tests with verbose output for CI.",
+      command: "vitest run --reporter=verbose",
+    },
+  ],
+  addFiles: [
+    {
+      destination: "vitest.config.ts",
+      content: `import { defineConfig } from "vitest/config"\n\nexport default defineConfig({\n  test: {\n    environment: "node",\n  },\n})\n`,
+    },
+  ],
+}

--- a/packages/create-next-stack/src/main/setup/setup.ts
+++ b/packages/create-next-stack/src/main/setup/setup.ts
@@ -34,6 +34,7 @@ import { styledComponentsPlugin } from "../plugins/styled-components.ts"
 import { tailwindCSSPlugin } from "../plugins/tailwind-css.ts"
 import { typescriptPlugin } from "../plugins/typescript.ts"
 import { vercelPlugin } from "../plugins/vercel.ts"
+import { vitestPlugin } from "../plugins/vitest.ts"
 import { yarnPlugin } from "../plugins/yarn.ts"
 import { getSteps } from "../steps.ts"
 import { printFinalMessages } from "./print-final-messages.ts"
@@ -67,6 +68,7 @@ export const plugins: Plugin[] = [
   vercelPlugin,
   netlifyPlugin,
   prismaPlugin,
+  vitestPlugin,
 ]
 
 export const filterPlugins = async (

--- a/packages/create-next-stack/src/tests/e2e/tests/vitest.test.ts
+++ b/packages/create-next-stack/src/tests/e2e/tests/vitest.test.ts
@@ -1,0 +1,20 @@
+import { exists } from "../../../main/helpers/exists.ts"
+import { testArgsWithFinalChecks } from "../helpers/test-args.ts"
+import { twentyMinutes } from "../helpers/timeout.ts"
+
+test(
+  "testVitest",
+  async () => {
+    const { runDirectory } = await testArgsWithFinalChecks([
+      "--debug",
+      "--package-manager=pnpm",
+      "--styling=tailwind-css",
+      "--vitest",
+      ".",
+    ])
+
+    const vitestConfigExists = await exists(`${runDirectory}/vitest.config.ts`)
+    expect(vitestConfigExists).toBe(true)
+  },
+  twentyMinutes,
+)


### PR DESCRIPTION
## Add support for Vitest (#224)

Closes #224

### Summary

Adds Vitest as a testing framework option via `--vitest` flag. When enabled, the generated project includes Vitest as a devDependency, test scripts, and a `vitest.config.ts` file.

### Changes

- **New plugin** `vitest.ts` with:
  - `vitest@^4.0.0` as devDependency (matching the version used internally by create-next-stack itself)
  - Scripts: `test` (`vitest run`), `test:watch` (`vitest`), `test:ci` (`vitest run --reporter=verbose`)
  - `vitest.config.ts` generated with `defineConfig` and `environment: "node"`
  - Technology metadata for README and landing page
- **CLI flag:** `--vitest` (boolean)
- **Plugin registration:** `vitestPlugin` added to `setup.ts`
- **Sort orders:** `vitest` added to technologies, `test:watch` and `test:ci` added to scripts

### Why

Vitest is the modern standard for testing in Vite-powered Next.js projects. Notably, create-next-stack itself already uses Vitest internally for its own test suite, but did not offer it as an option in the scaffold. This PR closes that gap.

### Verification

- ✅ `pnpm run build` — clean
- ✅ `pnpm run lint` — no errors
- ✅ `pnpm run unit` — 9/9 tests pass
- ✅ `./bin/run --help` shows `--vitest` flag

### Notes

- Vitest v4 is used to match the version used internally by create-next-stack.
- The generated `vitest.config.ts` uses `environment: "node"` as a sensible default. Users can customize it for DOM testing (jsdom/happy-dom) as needed.
- Website (create-next-stack.com) is NOT updated in this PR — can be done in a follow-up.