### PR TITLE
feat(cli): add Supabase as a backend option

### DIFF
--- a/packages/create-next-stack/README.md
+++ b/packages/create-next-stack/README.md
@@ -65,6 +65,7 @@ The table below provides an overview of the technologies currently supported by 
 | Vercel              | [Website](https://vercel.com/) - [Docs](https://vercel.com/docs) - [CLI Docs](https://vercel.com/docs/cli)                                                                                                                   |
 | Netlify             | [Website](https://www.netlify.com/) - [Docs](https://docs.netlify.com/) - [CLI Docs](https://cli.netlify.com/)                                                                                                               |
 | Prisma              | [Website](https://www.prisma.io/) - [Docs](https://www.prisma.io/docs) - [GitHub](https://github.com/prisma/prisma)                                                                                                          |
+| Supabase            | [Website](https://supabase.com/) - [Docs](https://supabase.com/docs) - [GitHub](https://github.com/supabase/supabase)                                                                                                        |
 
 <!-- CNS-END-OF-TECHNOLOGIES-TABLE -->
 
@@ -117,6 +118,7 @@ FLAGS
                                     method. (Required) <styling-method> =
                                     emotion|styled-components|tailwind-css|css-m
                                     odules|css-modules-with-sass
+      --supabase                    Adds Supabase. (Backend as a Service)
       --vercel                      Adds Vercel. (Hosting)
 ```
 

--- a/packages/create-next-stack/src/main/commands/create-next-stack.ts
+++ b/packages/create-next-stack/src/main/commands/create-next-stack.ts
@@ -125,6 +125,11 @@ export default class CreateNextStack extends Command {
     prisma: Flags.boolean({
       description: "Adds Prisma. (ORM)",
     }),
+
+    // Backend
+    supabase: Flags.boolean({
+      description: "Adds Supabase. (Backend as a Service)",
+    }),
   }
 
   async run(): Promise<void> {

--- a/packages/create-next-stack/src/main/plugins/create-next-stack/sort-orders/environment-variables.ts
+++ b/packages/create-next-stack/src/main/plugins/create-next-stack/sort-orders/environment-variables.ts
@@ -4,6 +4,8 @@ import { compareByOrder } from "../../../helpers/sort-by-order.ts"
 import { filterPlugins } from "../../../setup/setup.ts"
 
 export const environmentVariablesSortOrder: string[] = [
+  "NEXT_PUBLIC_SUPABASE_URL",
+  "NEXT_PUBLIC_SUPABASE_ANON_KEY",
   "NEXT_PUBLIC_WEBSITE_DOMAIN",
 ]
 

--- a/packages/create-next-stack/src/main/plugins/create-next-stack/sort-orders/technologies.ts
+++ b/packages/create-next-stack/src/main/plugins/create-next-stack/sort-orders/technologies.ts
@@ -34,6 +34,7 @@ export const technologiesSortOrder: string[] = [
   "vercel",
   "netlify",
   "prisma",
+  "supabase",
 ]
 
 export const getTechnologies = async (

--- a/packages/create-next-stack/src/main/plugins/supabase.ts
+++ b/packages/create-next-stack/src/main/plugins/supabase.ts
@@ -1,0 +1,97 @@
+import aldent from "aldent"
+import type { Plugin } from "../plugin.ts"
+
+const supabaseUrlEnvVar = "NEXT_PUBLIC_SUPABASE_URL"
+const supabaseAnonKeyEnvVar = "NEXT_PUBLIC_SUPABASE_ANON_KEY"
+
+export const supabasePlugin: Plugin = {
+  id: "supabase",
+  name: "Supabase",
+  description: "Adds support for Supabase",
+  active: ({ flags }) => Boolean(flags["supabase"]),
+  dependencies: [
+    { name: "@supabase/supabase-js", version: "^2.0.0" },
+    { name: "@supabase/ssr", version: "^0.6.0" },
+  ],
+  technologies: [
+    {
+      id: "supabase",
+      name: "Supabase",
+      description:
+        "Supabase is an open source Firebase alternative. It provides a PostgreSQL database, authentication, file storage, and realtime subscriptions, all accessible via a single client library. Supabase is designed to be backend-in-a-box, offering everything you need to build a full-stack application without managing infrastructure.",
+      links: [
+        { title: "Website", url: "https://supabase.com/" },
+        { title: "Docs", url: "https://supabase.com/docs" },
+        {
+          title: "GitHub",
+          url: "https://github.com/supabase/supabase",
+        },
+      ],
+    },
+  ],
+  environmentVariables: [
+    {
+      name: supabaseUrlEnvVar,
+      description:
+        "The URL of your Supabase project. Find it in your Supabase dashboard under Project Settings > API.",
+      defaultValue: "https://your-project.supabase.co",
+    },
+    {
+      name: supabaseAnonKeyEnvVar,
+      description:
+        "The anon (public) key of your Supabase project. Find it in your Supabase dashboard under Project Settings > API. This key is safe to expose in the browser.",
+      defaultValue: "your-anon-key",
+    },
+  ],
+  todos: [
+    `Create a project at https://supabase.com/dashboard and copy your project URL and anon key.`,
+    `Update the \`${supabaseUrlEnvVar}\` and \`${supabaseAnonKeyEnvVar}\` environment variables in \`.env\` with your Supabase project credentials.`,
+  ],
+  addFiles: [
+    {
+      destination: "lib/supabase/client.ts",
+      content: aldent`
+        import { createBrowserClient } from "@supabase/ssr"
+
+        export const createClient = () =>
+          createBrowserClient(
+            process.env.${supabaseUrlEnvVar}!,
+            process.env.${supabaseAnonKeyEnvVar}!,
+          )
+      `,
+    },
+    {
+      destination: "lib/supabase/server.ts",
+      content: aldent`
+        import { cookies } from "next/headers"
+        import { createServerClient } from "@supabase/ssr"
+
+        export const createClient = async () => {
+          const cookieStore = await cookies()
+
+          return createServerClient(
+            process.env.${supabaseUrlEnvVar}!,
+            process.env.${supabaseAnonKeyEnvVar}!,
+            {
+              cookies: {
+                getAll() {
+                  return cookieStore.getAll()
+                },
+                setAll(cookiesToSet) {
+                  try {
+                    cookiesToSet.forEach(({ name, value, options }) =>
+                      cookieStore.set(name, value, options),
+                    )
+                  } catch {
+                    // The \`setAll\` method was called from a Server Component.
+                    // This can be ignored if you have middleware refreshing user sessions.
+                  }
+                },
+              },
+            },
+          )
+        }
+      `,
+    },
+  ],
+}

--- a/packages/create-next-stack/src/main/setup/setup.ts
+++ b/packages/create-next-stack/src/main/setup/setup.ts
@@ -31,6 +31,7 @@ import { reactIconsPlugin } from "../plugins/react-icons.ts"
 import { reactQueryPlugin } from "../plugins/react-query.ts"
 import { sassPlugin } from "../plugins/sass.ts"
 import { styledComponentsPlugin } from "../plugins/styled-components.ts"
+import { supabasePlugin } from "../plugins/supabase.ts"
 import { tailwindCSSPlugin } from "../plugins/tailwind-css.ts"
 import { typescriptPlugin } from "../plugins/typescript.ts"
 import { vercelPlugin } from "../plugins/vercel.ts"
@@ -67,6 +68,7 @@ export const plugins: Plugin[] = [
   vercelPlugin,
   netlifyPlugin,
   prismaPlugin,
+  supabasePlugin,
 ]
 
 export const filterPlugins = async (

--- a/packages/create-next-stack/src/tests/e2e/tests/supabase.test.ts
+++ b/packages/create-next-stack/src/tests/e2e/tests/supabase.test.ts
@@ -1,0 +1,26 @@
+import { exists } from "../../../main/helpers/exists.ts"
+import { testArgsWithFinalChecks } from "../helpers/test-args.ts"
+import { twentyMinutes } from "../helpers/timeout.ts"
+
+test(
+  "testSupabase",
+  async () => {
+    const { runDirectory } = await testArgsWithFinalChecks([
+      "--debug",
+      "--package-manager=pnpm",
+      "--styling=tailwind-css",
+      "--supabase",
+      ".",
+    ])
+
+    const clientExists = await exists(`${runDirectory}/lib/supabase/client.ts`)
+    expect(clientExists).toBe(true)
+
+    const serverExists = await exists(`${runDirectory}/lib/supabase/server.ts`)
+    expect(serverExists).toBe(true)
+
+    const envExists = await exists(`${runDirectory}/.env`)
+    expect(envExists).toBe(true)
+  },
+  twentyMinutes,
+)


### PR DESCRIPTION
## Add support for Supabase (#249)

Closes #249

### Summary

Adds Supabase as a backend-as-a-service option via `--supabase` flag. This is a bare-bones hosted setup that generates browser and server clients for Next.js App Router, plus the required environment variables.

As noted in the issue, this PR starts with hosted Supabase support (connecting to a remote project). Local development with Docker can be added in a follow-up.

### Changes

- **New plugin** `supabase.ts` with:
  - `@supabase/supabase-js@^2.0.0` and `@supabase/ssr@^0.6.0` as dependencies
  - Browser client generated at `lib/supabase/client.ts` (uses `createBrowserClient`)
  - Server client generated at `lib/supabase/server.ts` (uses `createServerClient` with cookie handling for App Router)
  - Environment variables: `NEXT_PUBLIC_SUPABASE_URL`, `NEXT_PUBLIC_SUPABASE_ANON_KEY`
  - Technology metadata for README and landing page
  - Todo items guiding users to create a Supabase project and update env vars
- **CLI flag:** `--supabase` (boolean)
- **Plugin registration:** `supabasePlugin` added to `setup.ts`
- **Sort orders:** `supabase` added to technologies, Supabase env vars added to environment variables sort order

### Design decisions

- **Hosted only for v1:** The issue asks whether to start with hosted or local dev. Hosted is simpler and covers the most common use case. Local dev (Docker, `supabase init`) can be a follow-up.
- **`@supabase/ssr` over raw `@supabase/supabase-js`:** The SSR package is the official way to use Supabase with Next.js App Router, handling cookie-based auth in server components and route handlers.
- **No middleware generated:** Middleware for auth session refresh can be added later. Keeping the first PR focused on the client setup.
- **No type generation:** `supabase gen types` requires a live project URL. Users can run it after setting up their env vars.

### Verification

- ✅ `pnpm run build` — clean
- ✅ `pnpm run lint` — no errors
- ✅ `pnpm run unit` — 9/9 tests pass
- ✅ `./bin/run --help` shows `--supabase` flag

### Notes

- Website (create-next-stack.com) is NOT updated in this PR — can be done in a follow-up.
- The generated `lib/supabase/server.ts` uses `await cookies()` which requires Next.js 15+ (App Router). This is compatible with the Next.js 16 that create-next-stack currently scaffolds.