### PR TITLE
feat(cli): add Auth.js and shadcn/ui plugins

### DIFF
--- a/packages/create-next-stack/README.md
+++ b/packages/create-next-stack/README.md
@@ -65,6 +65,8 @@ The table below provides an overview of the technologies currently supported by 
 | Vercel              | [Website](https://vercel.com/) - [Docs](https://vercel.com/docs) - [CLI Docs](https://vercel.com/docs/cli)                                                                                                                   |
 | Netlify             | [Website](https://www.netlify.com/) - [Docs](https://docs.netlify.com/) - [CLI Docs](https://cli.netlify.com/)                                                                                                               |
 | Prisma              | [Website](https://www.prisma.io/) - [Docs](https://www.prisma.io/docs) - [GitHub](https://github.com/prisma/prisma)                                                                                                          |
+| Auth.js             | [Website](https://authjs.dev/) - [Docs](https://authjs.dev/getting-started) - [GitHub](https://github.com/nextauthjs/next-auth)                                                                                              |
+| shadcn/ui           | [Website](https://ui.shadcn.com/) - [Docs](https://ui.shadcn.com/docs) - [GitHub](https://github.com/shadcn-ui/ui)                                                                                                           |
 
 <!-- CNS-END-OF-TECHNOLOGIES-TABLE -->
 
@@ -85,6 +87,8 @@ ARGUMENTS
 FLAGS
   -h, --help                        Shows the CLI help information.
   -v, --version                     Shows the CLI version information.
+      --auth-js                     Adds Auth.js. (Authentication) (Requires App
+                                    Router)
       --chakra                      Adds Chakra UI. (Component library)
                                     (Requires Emotion)
       --debug                       Show verbose error messages for debugging
@@ -113,6 +117,8 @@ FLAGS
                                     router to use. App Router is the default and
                                     recommended option.
                                     <options: app|pages>
+      --shadcn                      Adds shadcn/ui. (Component library)
+                                    (Requires Tailwind CSS)
       --styling=<styling-method>    (required) Sets the preferred styling
                                     method. (Required) <styling-method> =
                                     emotion|styled-components|tailwind-css|css-m

--- a/packages/create-next-stack/src/main/commands/create-next-stack.ts
+++ b/packages/create-next-stack/src/main/commands/create-next-stack.ts
@@ -125,6 +125,17 @@ export default class CreateNextStack extends Command {
     prisma: Flags.boolean({
       description: "Adds Prisma. (ORM)",
     }),
+
+    // Authentication
+    "auth-js": Flags.boolean({
+      description: "Adds Auth.js. (Authentication) (Requires App Router)",
+    }),
+
+    // Component library
+    shadcn: Flags.boolean({
+      description:
+        "Adds shadcn/ui. (Component library) (Requires Tailwind CSS)",
+    }),
   }
 
   async run(): Promise<void> {

--- a/packages/create-next-stack/src/main/create-next-stack-types.ts
+++ b/packages/create-next-stack/src/main/create-next-stack-types.ts
@@ -87,6 +87,16 @@ export const validateFlags = (
       "Formatting pre-commit hook (category: Miscellaneous, flag: --formatting-pre-commit-hook) requires Prettier (category: Formatting, flag: --prettier).",
     )
   }
+  if (flags["auth-js"] && flags.router !== "app") {
+    throw new Error(
+      "Auth.js (category: Authentication, flag: --auth-js) requires App Router (flag: --router=app).",
+    )
+  }
+  if (flags.shadcn && flags.styling !== "tailwind-css") {
+    throw new Error(
+      "shadcn/ui (category: Component library, flag: --shadcn) requires Tailwind CSS (category: Styling, flag: --styling=tailwind-css).",
+    )
+  }
   return true
 }
 

--- a/packages/create-next-stack/src/main/plugins/auth-js.ts
+++ b/packages/create-next-stack/src/main/plugins/auth-js.ts
@@ -1,0 +1,63 @@
+import aldent from "aldent"
+import type { Plugin } from "../plugin.ts"
+
+const authSecretEnvVar = "AUTH_SECRET"
+
+export const authJsPlugin: Plugin = {
+  id: "auth-js",
+  name: "Auth.js",
+  description: "Adds support for Auth.js (NextAuth v5)",
+  active: ({ flags }) => Boolean(flags["auth-js"]),
+  dependencies: [{ name: "next-auth", version: "beta" }],
+  technologies: [
+    {
+      id: "authJs",
+      name: "Auth.js",
+      description:
+        "Auth.js (formerly NextAuth.js) is a complete open-source authentication solution for Next.js applications. It provides a set of APIs for handling authentication flows, supporting OAuth providers, email/password, magic links, and more. Auth.js v5 brings native App Router support, server-side session handling, and a simplified configuration API.",
+      links: [
+        { title: "Website", url: "https://authjs.dev/" },
+        { title: "Docs", url: "https://authjs.dev/getting-started" },
+        { title: "GitHub", url: "https://github.com/nextauthjs/next-auth" },
+      ],
+    },
+  ],
+  environmentVariables: [
+    {
+      name: authSecretEnvVar,
+      description:
+        "A random value used by Auth.js to encrypt tokens and email verification hashes. Generate one with `npx auth secret`.",
+      defaultValue: "your-secret-key",
+    },
+  ],
+  todos: [
+    `Generate an \`AUTH_SECRET\` by running \`npx auth secret\` and update the \`${authSecretEnvVar}\` environment variable.`,
+    `Configure your authentication providers in \`auth.ts\` by adding them to the \`providers\` array. See https://authjs.dev/getting-started/providers/oauth for OAuth setup.`,
+  ],
+  addFiles: [
+    {
+      destination: "auth.ts",
+      content: aldent`
+        import NextAuth from "next-auth"
+
+        export const { handlers, signIn, signOut, auth } = NextAuth({
+          providers: [],
+        })
+      `,
+    },
+    {
+      destination: "app/api/auth/[...nextauth]/route.ts",
+      content: aldent`
+        import { handlers } from "@/auth"
+
+        export const { GET, POST } = handlers
+      `,
+    },
+    {
+      destination: "proxy.ts",
+      content: aldent`
+        export { auth as proxy } from "@/auth"
+      `,
+    },
+  ],
+}

--- a/packages/create-next-stack/src/main/plugins/create-next-stack/sort-orders/environment-variables.ts
+++ b/packages/create-next-stack/src/main/plugins/create-next-stack/sort-orders/environment-variables.ts
@@ -4,6 +4,7 @@ import { compareByOrder } from "../../../helpers/sort-by-order.ts"
 import { filterPlugins } from "../../../setup/setup.ts"
 
 export const environmentVariablesSortOrder: string[] = [
+  "AUTH_SECRET",
   "NEXT_PUBLIC_WEBSITE_DOMAIN",
 ]
 

--- a/packages/create-next-stack/src/main/plugins/create-next-stack/sort-orders/scripts.ts
+++ b/packages/create-next-stack/src/main/plugins/create-next-stack/sort-orders/scripts.ts
@@ -12,6 +12,7 @@ export const scriptsSortOrder: string[] = [
   "lint",
   "format",
   "format:check",
+  "ui:add",
   "deploy:vercel",
   "deploy:netlify",
 ]

--- a/packages/create-next-stack/src/main/plugins/create-next-stack/sort-orders/technologies.ts
+++ b/packages/create-next-stack/src/main/plugins/create-next-stack/sort-orders/technologies.ts
@@ -34,6 +34,8 @@ export const technologiesSortOrder: string[] = [
   "vercel",
   "netlify",
   "prisma",
+  "authJs",
+  "shadcn",
 ]
 
 export const getTechnologies = async (

--- a/packages/create-next-stack/src/main/plugins/shadcn.ts
+++ b/packages/create-next-stack/src/main/plugins/shadcn.ts
@@ -1,0 +1,79 @@
+import aldent from "aldent"
+import type { Plugin } from "../plugin.ts"
+
+export const shadcnPlugin: Plugin = {
+  id: "shadcn",
+  name: "shadcn/ui",
+  description: "Adds support for shadcn/ui component library",
+  active: ({ flags }) => Boolean(flags["shadcn"]),
+  dependencies: [
+    { name: "class-variance-authority", version: "^0.7.0" },
+    { name: "clsx", version: "^2.1.0" },
+    { name: "tailwind-merge", version: "^3.0.0" },
+    { name: "tailwindcss-animate", version: "^1.0.0" },
+    { name: "lucide-react", version: "^0.400.0" },
+  ],
+  technologies: [
+    {
+      id: "shadcn",
+      name: "shadcn/ui",
+      description:
+        "shadcn/ui is a collection of beautifully designed, accessible components that you can copy and paste into your apps. Unlike traditional component libraries, shadcn/ui gives you ownership of the component code — no npm dependency to lock into. Built on Radix UI primitives and styled with Tailwind CSS, it offers full customization and composability.",
+      links: [
+        { title: "Website", url: "https://ui.shadcn.com/" },
+        { title: "Docs", url: "https://ui.shadcn.com/docs" },
+        { title: "GitHub", url: "https://github.com/shadcn-ui/ui" },
+      ],
+    },
+  ],
+  devDependencies: [{ name: "shadcn", version: "^4.0.0" }],
+  scripts: [
+    {
+      name: "ui:add",
+      description: "Adds a shadcn/ui component to the project.",
+      command: "shadcn add",
+    },
+  ],
+  todos: [
+    `Add components to your project by running \`pnpm dlx shadcn@latest add button\` (or any component name). See https://ui.shadcn.com/docs/components for the full list.`,
+  ],
+  addFiles: [
+    {
+      destination: "components.json",
+      content: aldent`
+        {
+          "$schema": "https://ui.shadcn.com/schema.json",
+          "style": "new-york",
+          "rsc": true,
+          "tsx": true,
+          "tailwind": {
+            "config": "",
+            "css": "app/globals.css",
+            "baseColor": "neutral",
+            "cssVariables": true,
+            "prefix": ""
+          },
+          "aliases": {
+            "components": "@/components",
+            "utils": "@/lib/utils",
+            "ui": "@/components/ui",
+            "lib": "@/lib",
+            "hooks": "@/hooks"
+          },
+          "iconLibrary": "lucide"
+        }
+      `,
+    },
+    {
+      destination: "lib/utils.ts",
+      content: aldent`
+        import { clsx, type ClassValue } from "clsx"
+        import { twMerge } from "tailwind-merge"
+
+        export function cn(...inputs: ClassValue[]) {
+          return twMerge(clsx(inputs))
+        }
+      `,
+    },
+  ],
+}

--- a/packages/create-next-stack/src/main/setup/setup.ts
+++ b/packages/create-next-stack/src/main/setup/setup.ts
@@ -7,6 +7,7 @@ import { inDebugMode } from "../helpers/in-debug-mode.ts"
 import { time } from "../helpers/time.ts"
 import { logDebug, logInfo } from "../logging.ts"
 import { evalOptionalProperty, evalProperty, type Plugin } from "../plugin.ts"
+import { authJsPlugin } from "../plugins/auth-js.ts"
 import { chakraUIPlugin } from "../plugins/chakra-ui.ts"
 import { createNextStackPlugin } from "../plugins/create-next-stack/create-next-stack.ts"
 import { cssModulesPlugin } from "../plugins/css-modules.ts"
@@ -29,6 +30,7 @@ import { reactPlugin } from "../plugins/react.ts"
 import { reactHookFormPlugin } from "../plugins/react-hook-form.ts"
 import { reactIconsPlugin } from "../plugins/react-icons.ts"
 import { reactQueryPlugin } from "../plugins/react-query.ts"
+import { shadcnPlugin } from "../plugins/shadcn.ts"
 import { sassPlugin } from "../plugins/sass.ts"
 import { styledComponentsPlugin } from "../plugins/styled-components.ts"
 import { tailwindCSSPlugin } from "../plugins/tailwind-css.ts"
@@ -67,6 +69,8 @@ export const plugins: Plugin[] = [
   vercelPlugin,
   netlifyPlugin,
   prismaPlugin,
+  authJsPlugin,
+  shadcnPlugin,
 ]
 
 export const filterPlugins = async (

--- a/packages/create-next-stack/src/tests/e2e/tests/auth-js-shadcn.test.ts
+++ b/packages/create-next-stack/src/tests/e2e/tests/auth-js-shadcn.test.ts
@@ -1,0 +1,37 @@
+import { exists } from "../../../main/helpers/exists.ts"
+import { testArgsWithFinalChecks } from "../helpers/test-args.ts"
+import { twentyMinutes } from "../helpers/timeout.ts"
+
+test(
+  "testAuthJsAndShadcn",
+  async () => {
+    const { runDirectory } = await testArgsWithFinalChecks([
+      "--debug",
+      "--package-manager=pnpm",
+      "--styling=tailwind-css",
+      "--auth-js",
+      "--shadcn",
+      ".",
+    ])
+
+    // Auth.js files
+    const authTsExists = await exists(`${runDirectory}/auth.ts`)
+    expect(authTsExists).toBe(true)
+
+    const authRouteExists = await exists(
+      `${runDirectory}/app/api/auth/[...nextauth]/route.ts`,
+    )
+    expect(authRouteExists).toBe(true)
+
+    const proxyExists = await exists(`${runDirectory}/proxy.ts`)
+    expect(proxyExists).toBe(true)
+
+    // shadcn/ui files
+    const componentsJsonExists = await exists(`${runDirectory}/components.json`)
+    expect(componentsJsonExists).toBe(true)
+
+    const utilsExists = await exists(`${runDirectory}/lib/utils.ts`)
+    expect(utilsExists).toBe(true)
+  },
+  twentyMinutes,
+)


### PR DESCRIPTION
## Add Auth.js and shadcn/ui (#268)

Closes #268

### Summary

Adds two new plugins: Auth.js (NextAuth v5) for authentication and shadcn/ui for accessible component library support.

### Auth.js plugin

- **Dependency:** `next-auth@beta` (v5)
- **Generated files:**
  - `auth.ts` — NextAuth config with empty providers array
  - `app/api/auth/[...nextauth]/route.ts` — route handler exporting GET/POST
  - `proxy.ts` — Next.js 16 middleware (session refresh)
- **Environment variable:** `AUTH_SECRET`
- **Validation:** requires App Router (`--router=app`)
- **Flag:** `--auth-js`

### shadcn/ui plugin

- **Dependencies:** `class-variance-authority`, `clsx`, `tailwind-merge`, `tailwindcss-animate`, `lucide-react`
- **Dev dependency:** `shadcn` (for CLI usage)
- **Generated files:**
  - `components.json` — shadcn config (new-york style, neutral base color, CSS variables enabled)
  - `lib/utils.ts` — `cn()` helper using clsx + tailwind-merge
- **Script:** `ui:add` (`shadcn add`) for adding components
- **Validation:** requires Tailwind CSS (`--styling=tailwind-css`)
- **Flag:** `--shadcn`

### Design decisions

- **Two separate plugins:** Auth.js and shadcn/ui can be used independently. The issue asks for both, but they don't depend on each other.
- **Auth.js v5 (beta):** This is the current version with native App Router support. The `proxy.ts` file follows the Next.js 16 naming convention (formerly `middleware.ts`).
- **shadcn/ui manual file generation:** Instead of running `shadcn init` (which is interactive), the plugin generates `components.json` and `lib/utils.ts` directly. Users can then run `shadcn add <component>` to add components as needed.
- **No components pre-installed:** The plugin sets up the infrastructure but doesn't add any shadcn components. Users choose what they need via `shadcn add`.

### Verification

- ✅ `pnpm run build` — clean
- ✅ `pnpm run lint` — no errors
- ✅ `pnpm run unit` — 9/9 tests pass
- ✅ `./bin/run --help` shows `--auth-js` and `--shadcn` flags
- ✅ Validation works: `--auth-js --router=pages` throws error
- ✅ Validation works: `--shadcn --styling=css-modules` throws error

### Notes

- Website (create-next-stack.com) is NOT updated in this PR.
- Auth.js requires App Router because v5 is designed for App Router. Pages Router support was dropped in v5.
- shadcn/ui requires Tailwind CSS because it's built on Tailwind.