### PR TITLE
fix(cli): skip initial commit when git user.name or user.email is not set

### DIFF
--- a/packages/create-next-stack/src/main/helpers/has-git-user-config.ts
+++ b/packages/create-next-stack/src/main/helpers/has-git-user-config.ts
@@ -1,0 +1,28 @@
+import { runCommand } from "./run-command.ts"
+
+/**
+ * `hasGitUserConfig` checks whether Git has `user.name` and `user.email` configured.
+ * Without these, `git commit` will fail with an error like:
+ * "Please tell me who you are" or "Author identity unknown".
+ *
+ * We check both `--global` and local config (in case global is unset but local exists).
+ *
+ * @returns `true` if both `user.name` and `user.email` are set, `false` otherwise
+ */
+export const hasGitUserConfig = async (): Promise<boolean> => {
+  try {
+    const userName = await runCommand("git", ["config", "user.name"])
+    const name =
+      typeof userName.stdout === "string" ? userName.stdout.trim() : ""
+    if (!name) return false
+
+    const userEmail = await runCommand("git", ["config", "user.email"])
+    const email =
+      typeof userEmail.stdout === "string" ? userEmail.stdout.trim() : ""
+    if (!email) return false
+
+    return true
+  } catch {
+    return false
+  }
+}

--- a/packages/create-next-stack/src/main/plugins/create-next-stack/create-next-stack.ts
+++ b/packages/create-next-stack/src/main/plugins/create-next-stack/create-next-stack.ts
@@ -3,6 +3,7 @@ import path from "path"
 import { copyDirectory } from "../../helpers/copy-directory.ts"
 import { getCreateNextStackDir } from "../../helpers/get-create-next-stack-dir.ts"
 import { modifyJsonFile, toObject, writeFile } from "../../helpers/io.ts"
+import { hasGitUserConfig } from "../../helpers/has-git-user-config.ts"
 import { isGitInitialized } from "../../helpers/is-git-initialized.ts"
 import { nonNull } from "../../helpers/non-null.ts"
 import { runCommand } from "../../helpers/run-command.ts"
@@ -180,6 +181,13 @@ export const createNextStackPlugin: Plugin = {
       shouldRun: async () => {
         if (!(await isGitInitialized())) {
           logWarning("Skipping initial commit, as Git was not initialized.")
+          return false
+        }
+        if (!(await hasGitUserConfig())) {
+          logWarning(
+            "Skipping initial commit, as Git user.name or user.email is not set. " +
+              'Configure them with `git config --global user.name "Your Name"` and `git config --global user.email "you@example.com"`.',
+          )
           return false
         }
         return true


### PR DESCRIPTION
## What

Fixes #231

The CLI was crashing when trying to run `git commit --amend` without `git user.name` or `user.email` configured. This happened because `isGitInitialized` only checks for the existence of `.git/`, not whether git identity is properly set up.

## Why

Create Next App may succeed at initializing git (creating `.git/`) but the subsequent `git commit --amend` from CNS fails if the user hasn't configured their git identity. This is common in CI/CD environments and fresh setups.

`create-next-app` handles this gracefully, so CNS should too.

## How

- Added `hasGitUserConfig` helper that checks both `user.name` and `user.email` via `git config`
- If either is missing, the initial commit step is skipped with a warning message instructing the user how to configure them
- The check uses `git config user.name` (without `--global`) so it works with both global and local config

## Testing

- `tsc --noEmit` passes
- Unit tests pass (`pnpm test:cli`)
- The fix follows the same pattern as the existing `isGitInitialized` check