### PR TITLE
feat(cli): add strict type-checked ESLint via typescript-eslint

### DIFF
--- a/packages/create-next-stack/README.md
+++ b/packages/create-next-stack/README.md
@@ -53,6 +53,7 @@ The table below provides an overview of the technologies currently supported by 
 | React Query         | [Website](https://tanstack.com/query/latest) - [Docs](https://tanstack.com/query/latest/docs/framework/react/overview) - [GitHub](https://github.com/tanstack/query)                                                         |
 | React Icons         | [Website](https://react-icons.github.io/react-icons/) - [GitHub](https://github.com/react-icons/react-icons)                                                                                                                 |
 | ESLint              | [Website](https://eslint.org/) - [Configuration](https://eslint.org/docs/user-guide/configuring/) - [Rules](https://eslint.org/docs/rules/) - [GitHub](https://github.com/eslint/eslint)                                     |
+| typescript-eslint   | [Website](https://typescript-eslint.io/) - [Configs](https://typescript-eslint.io/linting/configs) - [GitHub](https://github.com/typescript-eslint/typescript-eslint)                                                        |
 | Prettier            | [Website](https://prettier.io/) - [Docs](https://prettier.io/docs/en/index.html) - [Options](https://prettier.io/docs/en/options.html) - [GitHub](https://github.com/prettier/prettier)                                      |
 | Husky               | [Website](https://typicode.github.io/husky/) - [Docs](https://typicode.github.io/husky/) - [GitHub](https://github.com/typicode/husky)                                                                                       |
 | lint-staged         | [Website](https://github.com/lint-staged/lint-staged) - [GitHub](https://github.com/lint-staged/lint-staged)                                                                                                                 |
@@ -89,6 +90,9 @@ FLAGS
                                     (Requires Emotion)
       --debug                       Show verbose error messages for debugging
                                     purposes.
+      --eslint-strict               Adds strict type-checked linting via
+                                    typescript-eslint (strict-type-checked +
+                                    stylistic-type-checked).
       --formatting-pre-commit-hook  Adds a formatting pre-commit hook. (Requires
                                     Prettier)
       --formik                      Adds Formik. (Form library)

--- a/packages/create-next-stack/src/main/commands/create-next-stack.ts
+++ b/packages/create-next-stack/src/main/commands/create-next-stack.ts
@@ -98,6 +98,12 @@ export default class CreateNextStack extends Command {
       description: "Adds a formatting pre-commit hook. (Requires Prettier)",
     }),
 
+    // ESLint strict mode
+    "eslint-strict": Flags.boolean({
+      description:
+        "Adds strict type-checked linting via typescript-eslint (strict-type-checked + stylistic-type-checked).",
+    }),
+
     // Icons
     "react-icons": Flags.boolean({
       description: "Adds React Icons. (Icon library)",

--- a/packages/create-next-stack/src/main/plugins/create-next-stack/add-eslint-config/generate-eslint-config.ts
+++ b/packages/create-next-stack/src/main/plugins/create-next-stack/add-eslint-config/generate-eslint-config.ts
@@ -12,6 +12,14 @@ export const generateEslintConfig = async ({
 
   const configs = [`...nextVitals`, `...nextTs`]
 
+  if (flags["eslint-strict"]) {
+    imports.push(`import tseslint from "typescript-eslint"`)
+    configs.unshift(
+      `...tseslint.configs.strictTypeChecked`,
+      `...tseslint.configs.stylisticTypeChecked`,
+    )
+  }
+
   if (flags.prettier) {
     imports.push(`import eslintConfigPrettier from "eslint-config-prettier"`)
     configs.push(`eslintConfigPrettier`)
@@ -19,12 +27,24 @@ export const generateEslintConfig = async ({
 
   const configEntries = configs.map((c) => `    ${c},`).join("\n")
 
+  const parserOptions = flags["eslint-strict"]
+    ? `    {
+      languageOptions: {
+        parserOptions: {
+          projectService: true,
+          tsconfigRootDir: import.meta.dirname,
+        },
+      },
+    },
+`
+    : ""
+
   return aldent`
     ${imports.join("\n")}
 
     const eslintConfig = defineConfig([
     ${configEntries}
-      globalIgnores([
+      ${parserOptions}globalIgnores([
         ".next/**",
         "out/**",
         "build/**",

--- a/packages/create-next-stack/src/main/plugins/create-next-stack/sort-orders/technologies.ts
+++ b/packages/create-next-stack/src/main/plugins/create-next-stack/sort-orders/technologies.ts
@@ -22,6 +22,7 @@ export const technologiesSortOrder: string[] = [
   "reactQuery",
   "reactIcons",
   "eslint",
+  "typescript-eslint",
   "prettier",
   "husky",
   "lintStaged",

--- a/packages/create-next-stack/src/main/plugins/eslint-strict.ts
+++ b/packages/create-next-stack/src/main/plugins/eslint-strict.ts
@@ -1,0 +1,32 @@
+import type { Plugin } from "../plugin.ts"
+
+export const eslintStrictPlugin: Plugin = {
+  id: "eslint-strict",
+  name: "ESLint Strict (typescript-eslint)",
+  description:
+    "Adds strict type-checked linting via typescript-eslint (strict-type-checked + stylistic-type-checked)",
+  active: ({ flags }) => Boolean(flags["eslint-strict"]),
+  devDependencies: [{ name: "typescript-eslint", version: "^8.0.0" }],
+  technologies: [
+    {
+      id: "typescript-eslint",
+      name: "typescript-eslint",
+      description:
+        "typescript-eslint is the tooling that enables ESLint to run on TypeScript code. It provides a parser, plugin, and configurable rule sets ranging from recommended to strict type-checked rules.",
+      links: [
+        {
+          title: "Website",
+          url: "https://typescript-eslint.io/",
+        },
+        {
+          title: "Configs",
+          url: "https://typescript-eslint.io/linting/configs",
+        },
+        {
+          title: "GitHub",
+          url: "https://github.com/typescript-eslint/typescript-eslint",
+        },
+      ],
+    },
+  ],
+}

--- a/packages/create-next-stack/src/main/setup/setup.ts
+++ b/packages/create-next-stack/src/main/setup/setup.ts
@@ -12,6 +12,7 @@ import { createNextStackPlugin } from "../plugins/create-next-stack/create-next-
 import { cssModulesPlugin } from "../plugins/css-modules.ts"
 import { emotionPlugin } from "../plugins/emotion.ts"
 import { eslintPlugin } from "../plugins/eslint.ts"
+import { eslintStrictPlugin } from "../plugins/eslint-strict.ts"
 import { formattingPreCommitHookPlugin } from "../plugins/formatting-pre-commit-hook.ts"
 import { formikPlugin } from "../plugins/formik.ts"
 import { framerMotionPlugin } from "../plugins/framer-motion.ts"
@@ -55,6 +56,7 @@ export const plugins: Plugin[] = [
   formikPlugin,
   framerMotionPlugin,
   eslintPlugin,
+  eslintStrictPlugin,
   prettierPlugin,
   formattingPreCommitHookPlugin,
   pnpmPlugin,


### PR DESCRIPTION
## What

Addresses #263

Adds `--eslint-strict` flag that enables strict type-checked linting using [typescript-eslint](https://typescript-eslint.io/) (`strict-type-checked` + `stylistic-type-checked` configs).

## Why

Issue #263 asks for proper ESLint support with `@typescript-eslint`, including the ability to choose between official configurations. The repo already evolved to include `eslint-config-next/core-web-vitals` + `eslint-config-next/typescript` and `eslint-config-prettier`, but was missing the option to use stricter type-checked configs.

This PR adds the most impactful part of the checklist: the ability to opt into strict type-checked linting with a single flag.

## How

- New plugin `eslint-strict` activated when `--eslint-strict` flag is set
- Installs `typescript-eslint` as a devDependency
- `eslint.config.mjs` is generated with `tseslint.configs.strictTypeChecked` and `tseslint.configs.stylisticTypeChecked` prepended before the Next.js configs
- `parserOptions` with `projectService: true` and `tsconfigRootDir` are included for type-checked rules
- Added `typescript-eslint` to the technologies sort order for README/landing page

## What's left from #263

- Choosing between `next` and `next/core-web-vitals` (currently always uses core-web-vitals)
- Choosing between `recommended`, `strict`, `stylistic` and their type-checked variants individually

This PR provides the strict type-checked path. Further granularity can be added as follow-up.

## Testing

- `tsc --noEmit` passes
- Unit tests pass (`pnpm test:cli`)