### PR TITLE
feat(cli): add Zustand as a client state management option

### DIFF
--- a/packages/create-next-stack/README.md
+++ b/packages/create-next-stack/README.md
@@ -50,6 +50,7 @@ The table below provides an overview of the technologies currently supported by 
 | Motion              | [Website](https://motion.dev/) - [Docs](https://motion.dev/docs) - [GitHub](https://github.com/motiondivision/motion)                                                                                                        |
 | React Hook Form     | [Website](https://react-hook-form.com/) - [Docs](https://react-hook-form.com/get-started) - [GitHub](https://github.com/react-hook-form/react-hook-form)                                                                     |
 | Formik              | [Website](https://formik.org/) - [Docs](https://formik.org/docs/overview) - [GitHub](https://github.com/formium/formik)                                                                                                      |
+| Zustand             | [Website](https://zustand.docs.pmnd.rs/) - [Docs](https://zustand.docs.pmnd.rs/getting-started/introduction) - [GitHub](https://github.com/pmndrs/zustand)                                                                   |
 | React Query         | [Website](https://tanstack.com/query/latest) - [Docs](https://tanstack.com/query/latest/docs/framework/react/overview) - [GitHub](https://github.com/tanstack/query)                                                         |
 | React Icons         | [Website](https://react-icons.github.io/react-icons/) - [GitHub](https://github.com/react-icons/react-icons)                                                                                                                 |
 | ESLint              | [Website](https://eslint.org/) - [Configuration](https://eslint.org/docs/user-guide/configuring/) - [Rules](https://eslint.org/docs/rules/) - [GitHub](https://github.com/eslint/eslint)                                     |
@@ -118,6 +119,8 @@ FLAGS
                                     emotion|styled-components|tailwind-css|css-m
                                     odules|css-modules-with-sass
       --vercel                      Adds Vercel. (Hosting)
+      --zustand                     Adds Zustand. (Client state management
+                                    library)
 ```
 
 <!-- CNS-END-OF-HELP-OUTPUT -->

--- a/packages/create-next-stack/src/main/commands/create-next-stack.ts
+++ b/packages/create-next-stack/src/main/commands/create-next-stack.ts
@@ -108,6 +108,11 @@ export default class CreateNextStack extends Command {
       description: "Adds React Query. (Server state management library)",
     }),
 
+    // Client state management libraries
+    zustand: Flags.boolean({
+      description: "Adds Zustand. (Client state management library)",
+    }),
+
     // Analytics
     plausible: Flags.boolean({
       description: "Adds Plausible. (Analytics)",

--- a/packages/create-next-stack/src/main/plugins/create-next-stack/sort-orders/technologies.ts
+++ b/packages/create-next-stack/src/main/plugins/create-next-stack/sort-orders/technologies.ts
@@ -19,6 +19,7 @@ export const technologiesSortOrder: string[] = [
   "framerMotion",
   "reactHookForm",
   "formik",
+  "zustand",
   "reactQuery",
   "reactIcons",
   "eslint",

--- a/packages/create-next-stack/src/main/plugins/zustand.ts
+++ b/packages/create-next-stack/src/main/plugins/zustand.ts
@@ -1,0 +1,25 @@
+import type { Plugin } from "../plugin.ts"
+
+export const zustandPlugin: Plugin = {
+  id: "zustand",
+  name: "Zustand",
+  description: "Adds support for Zustand",
+  active: ({ flags }) => Boolean(flags.zustand),
+  dependencies: [{ name: "zustand", version: "^5.0.0" }],
+  technologies: [
+    {
+      id: "zustand",
+      name: "Zustand",
+      description:
+        "Zustand is a small, fast and scalable state-management solution with a comfortable API based on hooks. It is unopinionated and avoids the boilerplate of traditional state management libraries like Redux, while still providing a great developer experience.",
+      links: [
+        { title: "Website", url: "https://zustand.docs.pmnd.rs/" },
+        {
+          title: "Docs",
+          url: "https://zustand.docs.pmnd.rs/getting-started/introduction",
+        },
+        { title: "GitHub", url: "https://github.com/pmndrs/zustand" },
+      ],
+    },
+  ],
+}

--- a/packages/create-next-stack/src/main/setup/setup.ts
+++ b/packages/create-next-stack/src/main/setup/setup.ts
@@ -35,6 +35,7 @@ import { tailwindCSSPlugin } from "../plugins/tailwind-css.ts"
 import { typescriptPlugin } from "../plugins/typescript.ts"
 import { vercelPlugin } from "../plugins/vercel.ts"
 import { yarnPlugin } from "../plugins/yarn.ts"
+import { zustandPlugin } from "../plugins/zustand.ts"
 import { getSteps } from "../steps.ts"
 import { printFinalMessages } from "./print-final-messages.ts"
 
@@ -59,6 +60,7 @@ export const plugins: Plugin[] = [
   formattingPreCommitHookPlugin,
   pnpmPlugin,
   yarnPlugin,
+  zustandPlugin,
   npmPlugin,
   githubActionsPlugin,
   reactIconsPlugin,


### PR DESCRIPTION
## What

Closes #259

Adds `--zustand` flag that installs [Zustand](https://github.com/pmndrs/zustand) as a dependency and registers it in the technologies list.

## Why

Zustand is a lightweight client state management library with a hooks-based API. It complements React Query (server state) — when both are selected, users get a complete state management story.

Issue #259 requests this support.

## How

- New plugin `zustand` activated when `--zustand` flag is set
- Installs `zustand` as a dependency (not devDep — it's a runtime dependency)
- Adds Zustand to the technologies sort order for README/landing page
- No slots needed — Zustand stores are created per-component, no provider wrapper required

## Testing

- `tsc --noEmit` passes
- Unit tests pass (`pnpm test:cli`)