### PR TITLE
feat(cli): add Playwright as an E2E testing option

### DIFF
--- a/packages/create-next-stack/README.md
+++ b/packages/create-next-stack/README.md
@@ -51,6 +51,7 @@ The table below provides an overview of the technologies currently supported by 
 | React Hook Form     | [Website](https://react-hook-form.com/) - [Docs](https://react-hook-form.com/get-started) - [GitHub](https://github.com/react-hook-form/react-hook-form)                                                                     |
 | Formik              | [Website](https://formik.org/) - [Docs](https://formik.org/docs/overview) - [GitHub](https://github.com/formium/formik)                                                                                                      |
 | React Query         | [Website](https://tanstack.com/query/latest) - [Docs](https://tanstack.com/query/latest/docs/framework/react/overview) - [GitHub](https://github.com/tanstack/query)                                                         |
+| Playwright          | [Website](https://playwright.dev/) - [Docs](https://playwright.dev/docs/intro) - [GitHub](https://github.com/microsoft/playwright)                                                                                           |
 | React Icons         | [Website](https://react-icons.github.io/react-icons/) - [GitHub](https://github.com/react-icons/react-icons)                                                                                                                 |
 | ESLint              | [Website](https://eslint.org/) - [Configuration](https://eslint.org/docs/user-guide/configuring/) - [Rules](https://eslint.org/docs/rules/) - [GitHub](https://github.com/eslint/eslint)                                     |
 | Prettier            | [Website](https://prettier.io/) - [Docs](https://prettier.io/docs/en/index.html) - [Options](https://prettier.io/docs/en/options.html) - [GitHub](https://github.com/prettier/prettier)                                      |
@@ -103,6 +104,7 @@ FLAGS
                                     manager. (Required)
                                     <options: pnpm|yarn|npm>
       --plausible                   Adds Plausible. (Analytics)
+      --playwright                  Adds Playwright. (E2E testing framework)
       --prettier                    Adds Prettier. (Code formatting)
       --prisma                      Adds Prisma. (ORM)
       --react-hook-form             Adds React Hook Form. (Form library)

--- a/packages/create-next-stack/src/main/commands/create-next-stack.ts
+++ b/packages/create-next-stack/src/main/commands/create-next-stack.ts
@@ -113,6 +113,11 @@ export default class CreateNextStack extends Command {
       description: "Adds Plausible. (Analytics)",
     }),
 
+    // E2E testing
+    playwright: Flags.boolean({
+      description: "Adds Playwright. (E2E testing framework)",
+    }),
+
     // Hosting
     netlify: Flags.boolean({
       description: "Adds Netlify. (Hosting)",

--- a/packages/create-next-stack/src/main/plugins/create-next-stack/sort-orders/scripts.ts
+++ b/packages/create-next-stack/src/main/plugins/create-next-stack/sort-orders/scripts.ts
@@ -6,6 +6,8 @@ import { filterPlugins } from "../../../setup/setup.ts"
 export const scriptsSortOrder: string[] = [
   "prepare",
   "test",
+  "test:e2e",
+  "test:e2e:ui",
   "dev",
   "build",
   "start",

--- a/packages/create-next-stack/src/main/plugins/create-next-stack/sort-orders/technologies.ts
+++ b/packages/create-next-stack/src/main/plugins/create-next-stack/sort-orders/technologies.ts
@@ -20,6 +20,7 @@ export const technologiesSortOrder: string[] = [
   "reactHookForm",
   "formik",
   "reactQuery",
+  "playwright",
   "reactIcons",
   "eslint",
   "prettier",

--- a/packages/create-next-stack/src/main/plugins/playwright.ts
+++ b/packages/create-next-stack/src/main/plugins/playwright.ts
@@ -1,0 +1,40 @@
+import type { Plugin } from "../plugin.ts"
+
+export const playwrightPlugin: Plugin = {
+  id: "playwright",
+  name: "Playwright",
+  description: "Adds support for Playwright",
+  active: ({ flags }) => Boolean(flags.playwright),
+  devDependencies: [{ name: "@playwright/test", version: "^1.50.0" }],
+  technologies: [
+    {
+      id: "playwright",
+      name: "Playwright",
+      description:
+        "Playwright is a fast, reliable end-to-end testing framework that enables cross-browser testing across Chromium, Firefox, and WebKit with a single API. It provides auto-waiting, network interception, trace viewer, and codegen for generating tests from interactions.",
+      links: [
+        { title: "Website", url: "https://playwright.dev/" },
+        { title: "Docs", url: "https://playwright.dev/docs/intro" },
+        { title: "GitHub", url: "https://github.com/microsoft/playwright" },
+      ],
+    },
+  ],
+  scripts: [
+    {
+      name: "test:e2e",
+      description: "Runs end-to-end tests with Playwright.",
+      command: "playwright test",
+    },
+    {
+      name: "test:e2e:ui",
+      description: "Runs Playwright tests in interactive UI mode.",
+      command: "playwright test --ui",
+    },
+  ],
+  addFiles: [
+    {
+      destination: "playwright.config.ts",
+      content: `import { defineConfig, devices } from "@playwright/test"\n\nexport default defineConfig({\n  testDir: "./e2e",\n  fullyParallel: true,\n  forbidOnly: !!process.env.CI,\n  retries: process.env.CI ? 2 : 0,\n  workers: process.env.CI ? 1 : undefined,\n  reporter: "html",\n  use: {\n    baseURL: "http://localhost:3000",\n    trace: "on-first-retry",\n  },\n  projects: [\n    {\n      name: "chromium",\n      use: { ...devices["Desktop Chrome"] },\n    },\n  ],\n  webServer: {\n    command: "npm run dev",\n    url: "http://localhost:3000",\n    reuseExistingServer: !process.env.CI,\n  },\n})\n`,
+    },
+  ],
+}

--- a/packages/create-next-stack/src/main/setup/setup.ts
+++ b/packages/create-next-stack/src/main/setup/setup.ts
@@ -22,6 +22,7 @@ import { netlifyPlugin } from "../plugins/netlify.ts"
 import { nextPlugin } from "../plugins/next.ts"
 import { npmPlugin } from "../plugins/npm.ts"
 import { plausiblePlugin } from "../plugins/plausible.ts"
+import { playwrightPlugin } from "../plugins/playwright.ts"
 import { pnpmPlugin } from "../plugins/pnpm.ts"
 import { prettierPlugin } from "../plugins/prettier.ts"
 import { prismaPlugin } from "../plugins/prisma.ts"
@@ -64,6 +65,7 @@ export const plugins: Plugin[] = [
   reactIconsPlugin,
   reactQueryPlugin,
   plausiblePlugin,
+  playwrightPlugin,
   vercelPlugin,
   netlifyPlugin,
   prismaPlugin,


### PR DESCRIPTION
## What

Closes #223

Adds `--playwright` flag that installs [@playwright/test](https://playwright.dev/) and generates a sensible `playwright.config.ts`.

## Why

Playwright is the modern standard for E2E testing in the Next.js ecosystem. It complements Vitest (unit testing) — when both are selected, users get a complete testing story. Issue #223 requests this support.

## How

- New plugin `playwright` activated when `--playwright` flag is set
- Installs `@playwright/test` as a devDependency
- Generates `playwright.config.ts` with:
  - Chromium project (easy to extend)
  - `baseURL: http://localhost:3000`
  - `webServer` integration with `npm run dev` (auto-starts dev server)
  - Trace on first retry, HTML reporter
  - CI-aware (retries, workers, forbidOnly)
- Adds `test:e2e` and `test:e2e:ui` scripts
- Registered in scripts and technologies sort orders

## Testing

- `tsc --noEmit` passes
- Unit tests pass (`pnpm test:cli`)